### PR TITLE
Add random timer to apply damage to random structures

### DIFF
--- a/game/scenes/game/game.tscn
+++ b/game/scenes/game/game.tscn
@@ -172,6 +172,9 @@ damage_overlay_tile_map = NodePath("../DamageOverlay")
 script = ExtResource( 7 )
 structure_mgr = NodePath("../StructureMgr")
 
+[node name="DamageTimer" type="Timer" parent="DamageMgr"]
+one_shot = true
+
 [node name="Camera2D" type="Camera2D" parent="."]
 current = true
 __meta__ = {
@@ -239,3 +242,4 @@ bus = "Zoom3"
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="ZoomLevelSoundMixer/Zoom3Sound"]
 stream = ExtResource( 11 )
 volume_db = -12.0
+[connection signal="timeout" from="DamageMgr/DamageTimer" to="DamageMgr" method="_on_DamageTimer_timeout"]

--- a/game/scenes/managers/damage_mgr.gd
+++ b/game/scenes/managers/damage_mgr.gd
@@ -1,9 +1,12 @@
 extends Node
 
 export var structure_mgr: NodePath
+export var min_damage_time_interval = 1
+export var max_damage_time_interval = 5
 
 var _structure_mgr: StructureMgr
 
+var damage_active = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -11,13 +14,33 @@ func _ready():
 	if structure_mgr != null:
 		_structure_mgr = get_node_or_null(structure_mgr)
 
-
 func _on_random_damage_test_clicked():
 	if structure_mgr == null:
 		return
+	damage_active = !damage_active
+	if damage_active:
+		_start_random_damage_timer()
+	else:
+		$DamageTimer.stop()
+
+func _start_random_damage_timer():
+	if !damage_active:
+		return
+	$DamageTimer.wait_time = rand_range(min_damage_time_interval,max_damage_time_interval)
+	$DamageTimer.start()
+
+func _on_DamageTimer_timeout():
+	if !damage_active:
+		$DamageTimer.stop()
+		return
 	var non_damaged_structures = _structure_mgr.get_damagable_structures()
 	if non_damaged_structures == null || non_damaged_structures.size() < 1:
+		print("No valid structures to damage")
 		return
 	var rand_structure: StructureMgr.StructureData = ArrayUtil.get_rand(non_damaged_structures)
 	rand_structure.set_damaged(true)
+	var structure_mgr := StructureMgr.get_structure_mgr()
 	_structure_mgr.refresh_structure_resources()
+	print("damaged structure " + structure_mgr._structure_id_to_name[rand_structure.structure_type_id] )
+	# set random time for next damage
+	_start_random_damage_timer()

--- a/game/scenes/managers/structure_mgr.gd
+++ b/game/scenes/managers/structure_mgr.gd
@@ -159,6 +159,7 @@ func _init_structures_list():
 		var tile_id = _structure_tiles_tile_map.get_cellv(used_cell)
 		var structure = _create_structure_data_object(tile_id, used_cell)
 		structure.under_construction = false
+		
 		_structures[used_cell] = structure
 		_separator_boxes_tile_map.set_cellv(used_cell, _structure_enabled_status_overlay_tile_id)
 	

--- a/game/scenes/managers/structure_mgr.gd
+++ b/game/scenes/managers/structure_mgr.gd
@@ -159,7 +159,6 @@ func _init_structures_list():
 		var tile_id = _structure_tiles_tile_map.get_cellv(used_cell)
 		var structure = _create_structure_data_object(tile_id, used_cell)
 		structure.under_construction = false
-		
 		_structures[used_cell] = structure
 		_separator_boxes_tile_map.set_cellv(used_cell, _structure_enabled_status_overlay_tile_id)
 	

--- a/game/scenes/ui/hud.tscn
+++ b/game/scenes/ui/hud.tscn
@@ -79,6 +79,7 @@ margin_right = 70.0
 margin_bottom = 74.0
 hint_tooltip = "Randomly Damage a Structure
 (this is just for testing)"
+toggle_mode = true
 text = "Rnd Dmg"
 [connection signal="pressed" from="MarginContainer2/VBoxContainer/ResourceDialogBtn" to="." method="_on_ResourceDialogBtn_pressed"]
 [connection signal="pressed" from="MarginContainer2/VBoxContainer/RndDmgTestBtn" to="." method="_on_RndDmgTestBtn_pressed"]


### PR DESCRIPTION
Added a new timer node child to damage manager, this chooses a random wait time from a specified range, when it completes, it applies damage, then restarts the random range process.

 