### PR TITLE
Add Asteroid/Meteor Shower event to populate timeline

### DIFF
--- a/game/scenes/game/Asteroid.gd
+++ b/game/scenes/game/Asteroid.gd
@@ -1,7 +1,8 @@
 extends RigidBody2D
 
 var type = "Asteroid"
-var delayed_kick_impulse = Vector2(0,0)
+var delayed_kick_impulse = 0
+var delayed_torque_impulse = Vector2(0,0)
 var physics_tick_countdown = 10
 var apply_initial_force = true
 var disintegration_countdown = 3
@@ -25,7 +26,8 @@ func _physics_process(delta):
 			physics_tick_countdown -= 1
 
 func _give_asteroid_kick():
-	apply_impulse(Vector2(0,0), delayed_kick_impulse )
+	apply_impulse(Vector2(rand_range(-100,100),rand_range(-100,100)), delayed_kick_impulse )
+	apply_torque_impulse(delayed_torque_impulse)
 
 func _mark_for_disintegration():
 	marked_for_disintegration = true

--- a/game/scenes/game/DrivePlumePhysics.gd
+++ b/game/scenes/game/DrivePlumePhysics.gd
@@ -7,4 +7,4 @@ func _ready():
 func _on_DrivePlumePhysics_body_entered(body):
 	if "type" in body:
 		if body.type == "Fragment" or body.type == "Asteroid":
-			body.apply_impulse(Vector2(),Vector2(-5000,rand_range(-10,10)))
+			body.apply_impulse(Vector2(),Vector2(-20000,rand_range(-100,100)))

--- a/game/scenes/game/MoonSurfaceCollision.gd
+++ b/game/scenes/game/MoonSurfaceCollision.gd
@@ -1,15 +1,18 @@
 extends Area2D
 
+signal asteroid_impact()
 
 func _ready():
 	var extents = get_parent().radius
 	scale = Vector2(extents/10, extents/10)
+	SignalMgr.register_publisher(self, "asteroid_impact")
 
 
 func _body_impacted(body):
 	if "type" in body:
 		if body.type == "Asteroid":
 			var spawn_mgr = Globals.get("SpawnMgr")
+			emit_signal("asteroid_impact")
 			spawn_mgr._asteroid_impact(body)
 		else:
 			# other types of collsions?

--- a/game/scenes/game/game.tscn
+++ b/game/scenes/game/game.tscn
@@ -210,6 +210,7 @@ script = ExtResource( 32 )
 script = ExtResource( 33 )
 
 [node name="SpawnerMgr" parent="." instance=ExtResource( 9 )]
+min_time_between_asteroids = 1.0
 
 [node name="DamageMgr" type="Node" parent="."]
 script = ExtResource( 7 )

--- a/game/scenes/game/game.tscn
+++ b/game/scenes/game/game.tscn
@@ -210,7 +210,7 @@ script = ExtResource( 32 )
 script = ExtResource( 33 )
 
 [node name="SpawnerMgr" parent="." instance=ExtResource( 9 )]
-min_time_between_asteroids = 1.0
+min_time_between_asteroids = 4.0
 
 [node name="DamageMgr" type="Node" parent="."]
 script = ExtResource( 7 )

--- a/game/scenes/managers/SpawnerMgr.gd
+++ b/game/scenes/managers/SpawnerMgr.gd
@@ -30,6 +30,7 @@ export var fragment_propel_variance_min = 0.6
 export var fragment_propel_variance_max = 1.0
 export var shower_duration_min = 15
 export var shower_duration_max = 30
+export var range_of_time_between_showers = 50
 # in seconds
 var total_game_time = 0
 
@@ -102,13 +103,21 @@ func _is_out_of_bounds(body):
 
 func _initialize_timeline():
 	total_game_time = get_parent().get_node("Hud/TimeLine").game_time_length_minutes * 60
+	var time_before_events_start = 120
+	var adjusted_time_range = total_game_time - 120
 	var total_shower_events = randi() % (showers_per_game_max - showers_per_game_min) + showers_per_game_min
-	for x in range( 0, total_shower_events + 1 ):
-		var seconds_event = randi() % (total_game_time - 1) + 1
+	var interval = adjusted_time_range / total_shower_events
+	print("total shower evernts = " + str(total_shower_events))
+	for x in range( 0, total_shower_events  ):
+		var seconds_event = time_before_events_start + ( x * interval)
+		seconds_event += rand_range(-range_of_time_between_showers,range_of_time_between_showers)
+		if seconds_event > total_game_time:
+			seconds_event = total_game_time - (120 + rand_range(-20,20))
 		var event_dict = {}
 		event_dict["type"] = 0
 		event_dict["time"] = seconds_event
 		event_dict["duration"] = randi() % (shower_duration_max - shower_duration_min) + shower_duration_min
+		print(seconds_event)
 		if get_parent().get_node("Hud/TimeLine")._add_event_dict(event_dict):
 			pass
 		else:

--- a/game/scenes/managers/SpawnerMgr.gd
+++ b/game/scenes/managers/SpawnerMgr.gd
@@ -109,7 +109,10 @@ func _initialize_timeline():
 		event_dict["type"] = 0
 		event_dict["time"] = seconds_event
 		event_dict["duration"] = randi() % (shower_duration_max - shower_duration_min) + shower_duration_min
-		get_parent().get_node("Hud/TimeLine")._add_event_dict(event_dict)
+		if get_parent().get_node("Hud/TimeLine")._add_event_dict(event_dict):
+			pass
+		else:
+			print("adding event failed type = " + str(event_dict["type"] + " at " + str(event_dict["time"] + " seconds ")))
 
 func _spawn_asteroid():
 	if shower_active:

--- a/game/scenes/managers/SpawnerMgr.gd
+++ b/game/scenes/managers/SpawnerMgr.gd
@@ -9,27 +9,38 @@ var spawn_extents_min = Vector2(-13233,-9203.9)
 var spawn_extents_max = Vector2(13233,9203.9)
 
 onready var fragment_scene = preload("res://scenes/game/Fragment.tscn")
-export var min_time_between_asteroids:float = 1 #seconds
-export var max_time_between_asteroids:float = 5
+export var min_time_between_asteroids:float = 4 #seconds
+export var max_time_between_asteroids:float = 8
 export var debug := false
+
+export var showers_per_game_min = 5
+export var showers_per_game_max = 10
+
+var shower_active = false
 
 # how many asteroids can exist in scene at once
 export var max_concurrent_asteroids = 20
 
-var spawning_allowed = false
-
 # how many segments are launched after collision
-export var min_asteroid_segments: int = 2
-export var max_asteroid_segments: int = 5
+export var min_asteroid_segments: int = 4
+export var max_asteroid_segments: int = 8
 export var fragment_limit = 200
 # how much variance in the change in velocity by which they are ejected
-export var fragment_propel_variance_min = 0.4
-export var fragment_propel_variance_max = 0.8
+export var fragment_propel_variance_min = 0.6
+export var fragment_propel_variance_max = 1.0
+export var shower_duration_min = 15
+export var shower_duration_max = 30
+# in seconds
+var total_game_time = 0
+
+
+
 
 onready var spawn_limit_rect := $ReferenceRect
 
 func _ready():
 	Globals.set("SpawnMgr", self)
+	SignalMgr.register_subscriber(self, "AsteroidShowerEvent", "_on_AsteroidShowerEvent")
 	spawn_extents_min.x = spawn_limit_rect.rect_global_position.x
 	spawn_extents_min.y = spawn_limit_rect.rect_global_position.y
 	spawn_extents_max.x = abs(spawn_limit_rect.rect_global_position.x)
@@ -38,11 +49,23 @@ func _ready():
 	_load_sprites("res://assets/images/asteroids/fragments", fragment_sprites )
 	if asteroid_sprites.empty():
 		print("errror loading asteroid sprites")
-	else:
-		_start_spawn_timer()
-		spawning_allowed = true
-		
+
+func _on_AsteroidShowerEvent(event_dict):
+	if shower_active:
+		# new shower started during a current one
+		# just add the time on
+		var new_time = event_dict["time"]
+		$ShowerDurationTimer.wait_time += new_time
+	print("asteroid shower event signalled")
+	shower_active = true
+	$ShowerDurationTimer.wait_time = rand_range(shower_duration_min, shower_duration_max)
+	$ShowerDurationTimer.start()
+	_start_spawn_timer()
+
 func _process(delta):
+	if total_game_time == 0:
+		# initialize shower timeline
+		_initialize_timeline()
 	if fragments.size() > fragment_limit:
 		var to_remove = fragments[0]
 		fragments.erase(to_remove)
@@ -66,8 +89,19 @@ func _is_out_of_bounds(body):
 			return true
 	return false
 
+func _initialize_timeline():
+	total_game_time = get_parent().get_node("Hud/TimeLine").game_time_length_minutes * 60
+	var total_shower_events = randi() % (showers_per_game_max - showers_per_game_min) + showers_per_game_min
+	for x in range( 0, total_shower_events + 1 ):
+		var seconds_event = randi() % (total_game_time - 1) + 1
+		var event_dict = {}
+		event_dict["type"] = 0
+		event_dict["time"] = seconds_event
+		event_dict["duration"] = randi() % (shower_duration_max - shower_duration_min) + shower_duration_min
+		get_parent().get_node("Hud/TimeLine")._add_event_dict(event_dict)
+
 func _spawn_asteroid():
-	if spawning_allowed:
+	if shower_active:
 		if asteroids.size() >= max_concurrent_asteroids:
 			_start_spawn_timer()
 			return
@@ -86,14 +120,15 @@ func _spawn_asteroid():
 				spawn_pos.x = rand_range((spawn_extents_max.x / 2 ) + 100, spawn_extents_max.x - 100)
 			else:
 				#spawn right side
-				spawn_pos.x = (spawn_extents_max.x / 2) + 100
+				spawn_pos.x = (spawn_extents_max.x ) - 100
 				spawn_pos.y = rand_range(spawn_extents_min.y + 100, spawn_extents_max.y - 100)
-			var initial_kick = spawn_pos.direction_to(Vector2(0,0)).rotated(rand_range(-135,135))
-			initial_kick = initial_kick * rand_range( 500, 3000)
+			var initial_kick = spawn_pos.direction_to(Vector2(0,0)).rotated(rand_range(-45,45))
+			initial_kick = initial_kick * rand_range( 1000, 7500)
 			asteroid.position = spawn_pos
 			asteroids.append(asteroid)
 			# delay kick to let physics body settle after spawning
 			asteroid.delayed_kick_impulse = initial_kick
+			asteroid.delayed_torque_impulse = rand_range(-1000,1000)
 			add_child(asteroid)
 			if debug:
 				print("added asteroid at " + str(spawn_pos))
@@ -115,7 +150,7 @@ func _load_sprites(path, array):
 	direc.list_dir_end()
 	
 func _on_AsteroidTimer_timeout():
-	if !spawning_allowed:
+	if !shower_active:
 		$AsteroidTimer.stop()
 		return
 	_spawn_asteroid()
@@ -146,3 +181,6 @@ func _disintegrate(body):
 	asteroids.erase(body)
 	body.queue_free()
 
+func _on_ShowerDurationTimer_timeout():
+	shower_active = false
+	$AsteroidTimer.stop()

--- a/game/scenes/managers/SpawnerMgr.gd
+++ b/game/scenes/managers/SpawnerMgr.gd
@@ -51,14 +51,14 @@ func _ready():
 		print("errror loading asteroid sprites")
 
 func _on_AsteroidShowerEvent(event_dict):
+	var new_time = event_dict["duration"]
 	if shower_active:
 		# new shower started during a current one
-		# just add the time on
-		var new_time = event_dict["time"]
+		# just add the duration on
 		$ShowerDurationTimer.wait_time += new_time
 	print("asteroid shower event signalled")
 	shower_active = true
-	$ShowerDurationTimer.wait_time = rand_range(shower_duration_min, shower_duration_max)
+	$ShowerDurationTimer.wait_time = new_time
 	$ShowerDurationTimer.start()
 	_start_spawn_timer()
 
@@ -88,6 +88,14 @@ func _is_out_of_bounds(body):
 		body.global_position.y < spawn_extents_min.y - 1000:
 			return true
 	return false
+
+func _input(event):
+	if event.is_action_pressed("ui_focus_next") and not event.is_echo():
+		var new_event = {}
+		new_event["time"] = 0#dosnt matter
+		new_event["type"] = 0
+		new_event["duration"] = 100
+		_on_AsteroidShowerEvent(new_event)
 
 func _initialize_timeline():
 	total_game_time = get_parent().get_node("Hud/TimeLine").game_time_length_minutes * 60

--- a/game/scenes/managers/SpawnerMgr.gd
+++ b/game/scenes/managers/SpawnerMgr.gd
@@ -9,8 +9,8 @@ var spawn_extents_min = Vector2(-13233,-9203.9)
 var spawn_extents_max = Vector2(13233,9203.9)
 
 onready var fragment_scene = preload("res://scenes/game/Fragment.tscn")
-export var min_time_between_asteroids:float = 4 #seconds
-export var max_time_between_asteroids:float = 8
+export var min_time_between_asteroids:float = 1 #seconds
+export var max_time_between_asteroids:float = 2
 export var debug := false
 
 export var showers_per_game_min = 5
@@ -89,13 +89,16 @@ func _is_out_of_bounds(body):
 			return true
 	return false
 
-func _input(event):
-	if event.is_action_pressed("ui_focus_next") and not event.is_echo():
-		var new_event = {}
-		new_event["time"] = 0#dosnt matter
-		new_event["type"] = 0
-		new_event["duration"] = 100
-		_on_AsteroidShowerEvent(new_event)
+# testing, uncomment func below and press tab to spawn shower
+
+
+#func _input(event):
+#	if event.is_action_pressed("ui_focus_next") and not event.is_echo():
+#		var new_event = {}
+#		new_event["time"] = 0#dosnt matter
+#		new_event["type"] = 0
+#		new_event["duration"] = 100
+#		_on_AsteroidShowerEvent(new_event)
 
 func _initialize_timeline():
 	total_game_time = get_parent().get_node("Hud/TimeLine").game_time_length_minutes * 60

--- a/game/scenes/managers/SpawnerMgr.gd
+++ b/game/scenes/managers/SpawnerMgr.gd
@@ -13,9 +13,6 @@ export var min_time_between_asteroids:float = 1 #seconds
 export var max_time_between_asteroids:float = 2
 export var debug := false
 
-export var showers_per_game_min = 5
-export var showers_per_game_max = 10
-
 var shower_active = false
 
 # how many asteroids can exist in scene at once
@@ -28,13 +25,6 @@ export var fragment_limit = 200
 # how much variance in the change in velocity by which they are ejected
 export var fragment_propel_variance_min = 0.6
 export var fragment_propel_variance_max = 1.0
-export var shower_duration_min = 15
-export var shower_duration_max = 30
-export var range_of_time_between_showers = 50
-# in seconds
-var total_game_time = 0
-
-
 
 
 onready var spawn_limit_rect := $ReferenceRect
@@ -64,9 +54,6 @@ func _on_AsteroidShowerEvent(event_dict):
 	_start_spawn_timer()
 
 func _process(delta):
-	if total_game_time == 0:
-		# initialize shower timeline
-		_initialize_timeline()
 	if fragments.size() > fragment_limit:
 		var to_remove = fragments[0]
 		fragments.erase(to_remove)
@@ -101,27 +88,6 @@ func _is_out_of_bounds(body):
 #		new_event["duration"] = 100
 #		_on_AsteroidShowerEvent(new_event)
 
-func _initialize_timeline():
-	total_game_time = get_parent().get_node("Hud/TimeLine").game_time_length_minutes * 60
-	var time_before_events_start = 120
-	var adjusted_time_range = total_game_time - 120
-	var total_shower_events = randi() % (showers_per_game_max - showers_per_game_min) + showers_per_game_min
-	var interval = adjusted_time_range / total_shower_events
-	print("total shower evernts = " + str(total_shower_events))
-	for x in range( 0, total_shower_events  ):
-		var seconds_event = time_before_events_start + ( x * interval)
-		seconds_event += rand_range(-range_of_time_between_showers,range_of_time_between_showers)
-		if seconds_event > total_game_time:
-			seconds_event = total_game_time - (120 + rand_range(-20,20))
-		var event_dict = {}
-		event_dict["type"] = 0
-		event_dict["time"] = seconds_event
-		event_dict["duration"] = randi() % (shower_duration_max - shower_duration_min) + shower_duration_min
-		print(seconds_event)
-		if get_parent().get_node("Hud/TimeLine")._add_event_dict(event_dict):
-			pass
-		else:
-			print("adding event failed type = " + str(event_dict["type"] + " at " + str(event_dict["time"] + " seconds ")))
 
 func _spawn_asteroid():
 	if shower_active:

--- a/game/scenes/managers/SpawnerMgr.tscn
+++ b/game/scenes/managers/SpawnerMgr.tscn
@@ -4,8 +4,15 @@
 
 [node name="SpawnerMgr" type="Node"]
 script = ExtResource( 1 )
+min_time_between_asteroids = 4.0
+max_time_between_asteroids = 8.0
+fragment_propel_variance_min = 0.6
+fragment_propel_variance_max = 1.0
 
 [node name="AsteroidTimer" type="Timer" parent="."]
+one_shot = true
+
+[node name="ShowerDurationTimer" type="Timer" parent="."]
 one_shot = true
 
 [node name="ReferenceRect" type="ReferenceRect" parent="."]
@@ -18,3 +25,4 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 [connection signal="timeout" from="AsteroidTimer" to="." method="_on_AsteroidTimer_timeout"]
+[connection signal="timeout" from="ShowerDurationTimer" to="." method="_on_ShowerDurationTimer_timeout"]

--- a/game/scenes/managers/SpawnerMgr.tscn
+++ b/game/scenes/managers/SpawnerMgr.tscn
@@ -4,8 +4,8 @@
 
 [node name="SpawnerMgr" type="Node"]
 script = ExtResource( 1 )
-min_time_between_asteroids = 4.0
-max_time_between_asteroids = 8.0
+min_time_between_asteroids = 1.0
+max_time_between_asteroids = 2.0
 fragment_propel_variance_min = 0.6
 fragment_propel_variance_max = 1.0
 

--- a/game/scenes/managers/SpawnerMgr.tscn
+++ b/game/scenes/managers/SpawnerMgr.tscn
@@ -4,10 +4,6 @@
 
 [node name="SpawnerMgr" type="Node"]
 script = ExtResource( 1 )
-min_time_between_asteroids = 1.0
-max_time_between_asteroids = 2.0
-fragment_propel_variance_min = 0.6
-fragment_propel_variance_max = 1.0
 
 [node name="AsteroidTimer" type="Timer" parent="."]
 one_shot = true

--- a/game/scenes/ui/time_line.gd
+++ b/game/scenes/ui/time_line.gd
@@ -18,6 +18,8 @@ export var range_of_time_between_showers: int = 50
 export var showers_per_game_min: int = 5
 export var showers_per_game_max: int = 10
 
+var event_check_frequency = 30
+
 # sprite object and event time
 var timeline_markers = {}
 
@@ -136,9 +138,13 @@ func _clean_event_markers(event_dict):
 
 func _process(delta):
 	_current_time_seconds += delta
+	if event_check_frequency <= 0:
+		_check_event_schedule()
+		event_check_frequency = 30
+	else:
+		event_check_frequency -= 1
 	if _current_time_seconds >= _next_year_seconds:
 		_next_year_seconds += float(seconds_per_year)
-		_check_event_schedule()
 		emit_signal("YearHasElapsed")
 	var progress = _current_time_seconds / _game_time_length_seconds
 	_generation_ship_path_follow.unit_offset = progress

--- a/game/scenes/ui/time_line.gd
+++ b/game/scenes/ui/time_line.gd
@@ -2,7 +2,7 @@ extends MarginContainer
 
 signal YearHasElapsed()
 signal TimeHasExpired()
-
+signal AsteroidShowerEvent(event)
 
 export (int, 1, 60)  var game_time_length_minutes: int = 30
 export (int, 1, 60) var seconds_per_year: int = 1
@@ -11,23 +11,120 @@ var _current_time_seconds: float
 var _game_time_length_seconds: float
 var _next_year_seconds: float
 
+# sprite object and event time
+var timeline_markers = {}
+
+
+#TODO: more types?
+enum EventType {
+	MeteorShower
+}
+
+#array of dicts( sorted by timeline order )
+# event dict = enum:type, int:time(seconds), int:duration(seconds)
+var event_schedule = []
+
 onready var _marker_templates_parent := $MarkersTemplates
 onready var _generation_ship_path_follow := $Path2D/PathFollow2D
 
 
+class CustomSorter:
+	static func sort_ascending(a, b):
+		if a["time"] < b["time"]:
+			return true
+		return false
+
 func _ready():
 	SignalMgr.register_publisher(self, "YearHasElapsed")
 	SignalMgr.register_publisher(self, "TimeHasExpired")
+	SignalMgr.register_publisher(self, "AsteroidShowerEvent")
 	_game_time_length_seconds = game_time_length_minutes * 60
 	_next_year_seconds = float(seconds_per_year)
 	for c in _marker_templates_parent.get_children():
 		c.visible = false
 
+func _add_event_dict(event: Dictionary)->bool:
+	if event.has("type") and event["type"] in EventType.values() and \
+	event.has("time") and event.has("duration"):
+		event_schedule.push_back(event)
+		_sort_timeline_events()
+		_add_timeline_marker(event)
+		return true
+	else:
+		print("malformed event dictionary passed to timeline")
+		print(event)
+	return false
+	
+func _add_timeline_marker(event):
+	var new_sprite
+	if event["type"] == 0:#asteroid/meteor
+		new_sprite = $MarkersTemplates/meteor_shower_marker.duplicate()
+	# calculate where to place it, scaled according to game time
+	var total_seconds_in_game = game_time_length_minutes * 60
+	var timeline_length_in_pixels = $HBoxContainer/TextureRect2.rect_size.x
+	var scale = timeline_length_in_pixels / total_seconds_in_game
+	var seconds_to_pixels = event["time"] * scale
+	new_sprite.position.x = seconds_to_pixels + 20#offset
+	new_sprite.show()
+	timeline_markers[new_sprite] = event["time"]
+	$Markers.add_child(new_sprite)
+
+func _add_event(event_type:int, time:int, duration:int)->bool:
+	var event_dict = {}
+	if event_type in EventType.values():
+		event_dict["type"] = event_type
+	else:
+		print("incorrect event type sent to timeline")
+		print(event_type)
+		return false
+	event_dict["time"] = time
+	event_dict["duration"] = duration
+	event_schedule.push_back(event_dict)
+	_sort_timeline_events()
+	_add_timeline_marker(event_dict)
+	return true
+	
+func _sort_timeline_events():
+	event_schedule.sort_custom(CustomSorter, "sort_ascending")
+	
+func _check_event_schedule():
+	var closest_event = null
+	for x in event_schedule:
+		if closest_event == null:
+			closest_event = x
+		else:
+			if x["time"] < closest_event["time"]:
+				closest_event = x
+		var time_of_event = x["time"]
+		if _current_time_seconds > time_of_event:
+			if x["type"] == 0:
+				emit_signal("AsteroidShowerEvent", x.duplicate() )
+				event_schedule.erase(x)
+				_clean_event_markers(x)
+				#start one event at a time, even if only a few frames apart.
+				# simpler this way
+				return
+	var time_until_next_event = closest_event["time"] - int(_current_time_seconds)
+	if time_until_next_event < 20:
+		var type = ""
+		if closest_event["type"] == 0:
+			type = "Asteroid shower"
+		print("time until next " + type + " is " + str(time_until_next_event) + " time away")
+	
+
+func _clean_event_markers(event_dict):
+	var time_to_match = event_dict["time"]
+	for x in timeline_markers.keys():
+		if time_to_match == timeline_markers[x]:
+			timeline_markers.erase(x)
+			x.queue_free()
+			
 
 func _process(delta):
 	_current_time_seconds += delta
 	if _current_time_seconds >= _next_year_seconds:
 		_next_year_seconds += float(seconds_per_year)
+		_check_event_schedule()
 		emit_signal("YearHasElapsed")
 	var progress = _current_time_seconds / _game_time_length_seconds
 	_generation_ship_path_follow.unit_offset = progress

--- a/game/utils/transitionMgr.tscn
+++ b/game/utils/transitionMgr.tscn
@@ -67,4 +67,5 @@ polygon = PoolVector2Array( -2000, -2000, -2000, 2000, 2000, 2000, 2000, -2000 )
 [node name="fadeAnimation" type="AnimationPlayer" parent="."]
 anims/fadeIn = SubResource( 1 )
 anims/fadeOut = SubResource( 2 )
+
 [connection signal="animation_finished" from="fadeAnimation" to="." method="_on_fadeAnimation_animation_finished"]

--- a/game/utils/transitionMgr.tscn
+++ b/game/utils/transitionMgr.tscn
@@ -67,5 +67,4 @@ polygon = PoolVector2Array( -2000, -2000, -2000, 2000, 2000, 2000, 2000, -2000 )
 [node name="fadeAnimation" type="AnimationPlayer" parent="."]
 anims/fadeIn = SubResource( 1 )
 anims/fadeOut = SubResource( 2 )
-
 [connection signal="animation_finished" from="fadeAnimation" to="." method="_on_fadeAnimation_animation_finished"]


### PR DESCRIPTION
Added system which populates the timeline UI with the relevant events
based on a dictionary-per-event structure which contains time, duration and type ( only one type so far )

these dictionaries are added to an array, which is then checked in process() and then pruned if one has  reached the current time, then a signal is fired, and the asteroid shower is spawned, 

Fixed a couple of small things also - asteroids were not spawning on right-hand edge of screen, and changed asteroid impact to register with the signal manager ( for future sound effects and so on )